### PR TITLE
Add function to retrieve multiple tasks by their IDs

### DIFF
--- a/binding/task.go
+++ b/binding/task.go
@@ -15,6 +15,12 @@ func (h *Task) Create(r *api.Task) (err error) {
 	return
 }
 
+// Get multiple tasks by their IDs.
+func (h *Task) GetTasksByIds(ids []uint) (tasks []api.Task, err error) {
+    err = h.client.Post(api.TasksReportQueueRootByIds, ids, &tasks)
+    return
+}
+
 // Get a Task by ID.
 func (h *Task) Get(id uint) (r *api.Task, err error) {
 	r = &api.Task{}


### PR DESCRIPTION
This PR introduces a new function, GetTasksByIds, which allows retrieval of multiple tasks based on a list of task IDs. This function was added to the Task handler to improve functionality and efficiency when multiple task details are needed in one request